### PR TITLE
Bump R-CMD-check-action to v2

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: r-lib/actions/setup-tinytex@v2
-      - uses: uclahs-cds/tool-R-CMD-check-action@stable
+      - uses: uclahs-cds/tool-R-CMD-check-action@v2


### PR DESCRIPTION
This PR updates the `R CMD check` action to its newest `v2` release.
